### PR TITLE
Fix up button

### DIFF
--- a/pluginner/Widgets/FileListPanel.cs
+++ b/pluginner/Widgets/FileListPanel.cs
@@ -2,6 +2,7 @@
  * The file list widget
  * (C) The File Commander Team - https://github.com/atauenis/fcmd
  * (C) 2013-14, Alexander Tauenis (atauenis@yandex.ru)
+ * (C) 2014, Zhigunov Andrew (breakneck11@gmail.com)
  * Contributors should place own signs here.
  */
 


### PR DESCRIPTION
Пофикшен баг с неправильным поведением кнопки ".." (еще, параллельно, и "/" тоже).
Суть в том, что для нее при каждой смене директории добавлялись обработчики событий _Click_, при этом, старые не очищались, и при очередной смене папки кнопкой ".." открывались все папки, когда-либо открытые с ее помощью.
Т.к. в C# нет штатных средств очистки события, то пришлось запоминать последнее добавленное и при смене его удалять.
