### PR TITLE
Speed improvement

### DIFF
--- a/base-plugins/fs/localFileSystem.cs
+++ b/base-plugins/fs/localFileSystem.cs
@@ -86,13 +86,12 @@ namespace fcmd.base_plugins.fs
 			}
 
 			uint counter = 0;
-			// 2 ** 17 ~= 100000 (is about 100000)
-			// so dispatching will be done every time 100000 files
-			// will have been looked throught
-			// update_every == 00...0011...11 in binary format and count of 1 is 17
-			// so (++counter & update_every) == 0 will be true after every 2 ** 17 ~= 100000
+			// 2 ** 10 ~= 1000 (is about 1000)
+			// so dispatching will be done every time 1000 files will have been looked throught
+			// update_every == 00...0011...11 in binary format and count of '1' is 10
+			// so (++counter & update_every) == 0 will be true after every 2 ** 10 ~= 1000
 			// passed files
-			const uint update_every = ~(((~(uint)0) >> 17) << 17);
+			const uint update_every = ~(((~(uint)0) >> 10) << 10);
 
 			foreach(string curDir in dirs){
 				//перебираю каталоги

--- a/fcmd.sln
+++ b/fcmd.sln
@@ -45,9 +45,6 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = fcmd.csproj
 	EndGlobalSection


### PR DESCRIPTION
**tl;dr** Раньше папка Windows открывалась ~8 секунд, теперь практически мгновенно.

Занялся улучшением скорости работы.
Запустил профайлер и обнаружил, что при открытии новой директории over 80% времени съедает функция DispatchPendingEvents. Насколько я понял, она заставляет обработать поступившие сообщения, проблема только в том, что, выполняясь на каждой итерации цикла, она начинает отжирать столько времени, что без нее юзер давно получил бы результат; другими словами, если ее удалить, то все начинает работать настолько быстро, что за время загрузки директории почти невозможно успеть что-либо нажать, обрабатывать нечего и она практически не нужна.

Тем не менее, с заделом на большие каталоги, сделано так, что она вызывается каждые 1000 обработанных файлов и/или директорий.
