### PR TITLE
More speed improvement

### DIFF
--- a/fcmd.sln
+++ b/fcmd.sln
@@ -45,6 +45,9 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = fcmd.csproj
 	EndGlobalSection

--- a/pluginner/Toolkit/Utilities.cs
+++ b/pluginner/Toolkit/Utilities.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using Xwt;
 using Xwt.Drawing;
+using System.Collections.Generic;
 using Application = System.Windows.Forms.Application;
 using Color = Xwt.Drawing.Color;
 using Image = Xwt.Drawing.Image;
@@ -22,6 +23,15 @@ namespace pluginner.Toolkit
 	public static class Utilities
 	{
 		static string PathToIcons = Application.StartupPath + Path.DirectorySeparatorChar + "icons";
+
+		static Dictionary<string, Image> cached_images = new Dictionary<string, Image>();
+
+		static Image GetLocalIcon(string path) {
+			if (!cached_images.ContainsKey(path)) {
+				cached_images[path] = Image.FromResource(path);
+			}
+			return cached_images[path];
+		}
 
 		//These functions is partially equivalents of the Xwt.MessageDialog ones
 		//but they works at UI thread and in fact are macros.
@@ -137,10 +147,10 @@ namespace pluginner.Toolkit
 		public static Image GetIconForMIME(string MIME)
 		{
 			if (MIME == "x-fcmd/directory")
-				return Image.FromResource("pluginner.Resources.x-fcmd-directory.png");
+				return GetLocalIcon("pluginner.Resources.x-fcmd-directory.png");
 			
 			if (MIME == "x-fcmd/up")
-				return Image.FromResource("pluginner.Resources.x-fcmd-up.png");
+				return GetLocalIcon("pluginner.Resources.x-fcmd-up.png");
 
 			if (CheckForIcon(MIME.Replace("/","-"))){
 				return GetIconFromCache(MIME.Replace("/", "-"));
@@ -269,7 +279,7 @@ namespace pluginner.Toolkit
 			if(MIME != "application/octet-stream")
 			Console.WriteLine("utilities: Can't find an icon for " + MIME);
 #endif
-			return Image.FromResource("pluginner.Resources.application-octet-stream.png");
+			return GetLocalIcon("pluginner.Resources.application-octet-stream.png");
 		}
 
 		/// <summary>Finds a MIME content-type of a file</summary>

--- a/pluginner/Widgets/FileListPanel.cs
+++ b/pluginner/Widgets/FileListPanel.cs
@@ -405,6 +405,8 @@ namespace pluginner.Widgets
 				UrlBox.Text = URL;
 				string updir = URL + FS.DirSeparator+"..";
 				string rootdir = FS.GetMetadata(URL).RootDirectory;
+				uint counter = 0;
+				const uint per_number = ~(((~(uint)0) >> 10) << 10);
 
 				foreach (DirItem di in dis)
 				{
@@ -432,6 +434,9 @@ namespace pluginner.Widgets
 					}
 					Data.Add(di);
 					ListingView.AddItem(Data, EditableFileds, di.Path);
+					if ((++counter & per_number) == 0) {
+						Application.MainLoop.DispatchPendingEvents();
+					}
 				}
 				if (goUpDelegate != null) {
 					GoUp.Clicked -= goUpDelegate;

--- a/pluginner/Widgets/ListView2.cs
+++ b/pluginner/Widgets/ListView2.cs
@@ -28,7 +28,6 @@ namespace pluginner.Widgets
 		private Views _View = Views.Details;
 		//todo: int MaxRow (для переноса при режиме Small Icons)
 		private List<ColumnInfo> _columns = new List<ColumnInfo>();
-		private int Through10Counter; //для устранения зависания UI при загрузке длинных списков
 		private bool Color2; //для обеспечения чередования цветов строк
 		private DateTime PointedItemLastClickTime = DateTime.Now.AddDays(-1); //for double click detecting
 
@@ -330,13 +329,6 @@ namespace pluginner.Widgets
 			Item.CanGetFocus = true;
 			if (LastRow == 0) _SetPoint(Item);
 			LastRow++;
-
-			Through10Counter++;
-			if (Through10Counter == 250)
-			{
-				Application.MainLoop.DispatchPendingEvents();
-				Through10Counter = 0;
-			}
 		}
 
 		/// <summary>Removes the specifed item from the list</summary>


### PR DESCRIPTION
Практически все, что можно выжать, с текущей структурой без изменения подхода к считыванию директорий.
>80% времени отводится на сторонние библиотеки (читай Xwt)
~20% времени еще отводится на `DispatchPendingEvents`, можно еще поиграться с тем, как часто запускать `DispatchPendingEvents`, но это кажется неблагодарным занятием (да, даже правило **80/20** иногда попадается в чистом виде).
